### PR TITLE
Allow nCols on nTabs

### DIFF
--- a/pydatview/GUIInfoPanel.py
+++ b/pydatview/GUIInfoPanel.py
@@ -388,29 +388,23 @@ class InfoPanel(wx.Panel):
          Each column represents one subplot and each
          row/pair value represents signal-index that
          needs to be plotted: 1 -> left, 2 -> right, 0 -> not.
-         This is only valid in tab-mode == '1Tab_nCols'.
         """
-        if self.tab_mode == '1Tab_nCols':
-            if not self.plotMatrixPanel.IsShown():
-                # keep panel, display plots normally
-                plot_matrix = None
-            else:
-                nr_signals = len(PD)
-                nr_subplots = self.getNumberOfSubplots(PD, sub)
-                plot_matrix  = [[0 for x in range(nr_subplots)] for y in range(nr_signals)]
-                for i in range(nr_signals ** 2):
-                    # iterate over rows where each corresponds to one signal
-                    subplot = i % nr_signals
-                    signal = int(i / nr_signals)
-                    selection = self.plotMatrixPanel.Children[i].GetLabelText()
-                    if selection == '1':
-                        plot_matrix[signal][subplot] = 1
-                    elif selection == '2':
-                        plot_matrix[signal][subplot] = 2
-        else:
-            # Destroy plot matrix panel
-            self.getNumberOfSubplots([], sub)
+        if not self.plotMatrixPanel.IsShown():
+            # keep panel, display plots normally
             plot_matrix = None
+        else:
+            nr_signals = len(PD)
+            nr_subplots = self.getNumberOfSubplots(PD, sub)
+            plot_matrix  = [[0 for x in range(nr_subplots)] for y in range(nr_signals)]
+            for i in range(nr_signals ** 2):
+                # iterate over rows where each corresponds to one signal
+                subplot = i % nr_signals
+                signal = int(i / nr_signals)
+                selection = self.plotMatrixPanel.Children[i].GetLabelText()
+                if selection == '1':
+                    plot_matrix[signal][subplot] = 1
+                elif selection == '2':
+                    plot_matrix[signal][subplot] = 2
         return plot_matrix
     
     def setCol(self, name, value):

--- a/pydatview/GUIPlotPanel.py
+++ b/pydatview/GUIPlotPanel.py
@@ -992,7 +992,7 @@ class PlotPanel(wx.Panel):
         if mode=='1Tab_nCols':
             if bSubPlots:
                 if bCompare or len(uTabs)==1:
-                    nSubPlots = self.infoPanel.getNumberOfSubplots(PD, self.cbSub.IsChecked())
+                    nSubPlots = self.infoPanel.getNumberOfSubplots(PD, bSubPlots)
                 else:
                     nSubPlots=len(usy)
                 spreadBy='iy'
@@ -1013,7 +1013,11 @@ class PlotPanel(wx.Panel):
                 if bCompare:
                     print('>>>TODO ',mode,len(usy),len(uTabs))
                 else:
-                    nSubPlots=int(len(PD)/len(uTabs))
+                    # nSubPlots=int(len(PD)/len(uTabs))
+                    if bCompare or len(uTabs)==1:
+                        nSubPlots = self.infoPanel.getNumberOfSubplots(PD, bSubPlots)
+                    else:
+                        nSubPlots=len(PD)
                     spreadBy='mod-ip'
         elif mode=='nTabs_1Col':
             if bSubPlots:
@@ -1080,8 +1084,9 @@ class PlotPanel(wx.Panel):
                     else:
                         pd.syl=pd.sy #pd.syl=pd.st + ' - '+pd.sy
         elif mode=='nTabs_SimCols':
+            usy=unique([pd.sy for pd in self.plotData])
             bSubPlots = self.cbSub.IsChecked()
-            if bSubPlots: # spread by table name
+            if bSubPlots and len(usy)==1: # spread by table name
                 for pd in self.plotData:
                     pd.syl=pd.st
             else:

--- a/pydatview/GUISelectionPanel.py
+++ b/pydatview/GUISelectionPanel.py
@@ -1192,13 +1192,13 @@ class SelectionPanel(wx.Panel):
                 ISel=self.tabPanel.lbTab.GetSelections()
                 if self.tabList.haveSameColumns(ISel):
                     pass # TODO: this test is identical to onTabSelectionChange. Unification.
-                elif len(ISel)==2:
-                    self.colPanel1.forceOneSelection()
-                    self.colPanel2.forceOneSelection()
-                elif len(ISel)==3:
-                    self.colPanel1.forceOneSelection()
-                    self.colPanel2.forceOneSelection()
-                    self.colPanel3.forceOneSelection()
+                # elif len(ISel)==2:
+                #     self.colPanel1.forceOneSelection()
+                #     self.colPanel2.forceOneSelection()
+                # elif len(ISel)==3:
+                #     self.colPanel1.forceOneSelection()
+                #     self.colPanel2.forceOneSelection()
+                #     self.colPanel3.forceOneSelection()
 
     def update_tabs(self, tabList):
         self.setTables(tabList, update=True)

--- a/pydatview/pydatview.py
+++ b/pydatview/pydatview.py
@@ -285,10 +285,13 @@ class MainFrame(wx.Frame):
         if not bAdd:
             self.clean_memory(bReload=bReload)
 
+        base_filenames = [os.path.basename(f) for f in filenames]
+        filenames = [f for __, f in sorted(zip(base_filenames, filenames))]
         warn = self.tabList.load_tables_from_files(filenames=filenames, fileformat=fileformat, bAdd=bAdd)
         if bReload:
             # Restore formulas that were previously added
-            ITab, __ = self.selPanel.getAllTables()
+            _ITab, _STab = self.selPanel.getAllTables()
+            ITab = [iTab for __, iTab in sorted(zip(_STab, _ITab))]
             if len(ITab) != len(self.restore_formulas):
                 raise ValueError('Invalid length of tabs and formulas!')
             for iTab, f_list in zip(ITab, self.restore_formulas):


### PR DESCRIPTION
As soon as more than one column per table is selected this switches to nTabs_SimCols-mode which adds table names to legends unless the signals have unique names.
Matrix is displayed for any table-col-mode.
Formula reload fixed.