### PR TITLE
breaking changes in numpy 2.x, avoiding it for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openpyxl
-numpy
+numpy<2.0
 pandas
 xarray
 pyarrow # for parquet files


### PR DESCRIPTION
Error importing `numpy.core.multiarray` in `numpy 2.x` is causing `pydativew` to break.

https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-lib-namespace